### PR TITLE
fix: route API requests to api domain

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -24,8 +24,8 @@ https://memedam.com/* https://www.memedam.com/:splat 301!
 /memes/all?page=0* /memes/all 301
 
 # API 路由處理（若有反向代理請替換正確網域，避免被 Google 當可索引根）
-# 如需代理：取消下一行註解並設置正確 API 主機
-# /api/* https://api.memedam.com/:splat 200
+# 啟用代理：將 /api/* 轉發到後端 API 主機
+/api/* https://api.memedam.com/:splat 200
 
 # SPA 路由處理（單一規則即可）
 /*    /index.html   200


### PR DESCRIPTION
## Summary
- forward `/api/*` paths to the backend host to keep auth redirects on `api.memedam.com`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 14 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b592a7a7388323bcd002ecc94560e5